### PR TITLE
Adding Automatic S3 Bucket Setup

### DIFF
--- a/bucket.tf.json
+++ b/bucket.tf.json
@@ -1,0 +1,8 @@
+{
+	"variable": {
+		"bucket_name": {
+			"description": "The name of the bucket in which the terraform remote state is stored.",
+			"default": "marcboudreau-371d9884"
+		}
+	}
+}

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,28 @@
+test:
+  override:
+    - |
+      set -exo pipefail
+      export BUCKET_NAME=$(jq -r '.variable.bucket_name.default' bucket.tf.json)-test
+      ./setup-bucket.sh
+      test -z "$(aws s3api get-bucket-acl \
+          --bucket $BUCKET_NAME | \
+        jq -r '.Grants[].Grantee | select(.URI == "http://acs.amazonaws.com/groups/global/AuthenticatedUsers")')"
+      aws s3api put-bucket-acl \
+          --bucket $BUCKET_NAME \
+          --acl authenticated-read
+    - |
+      set -exo pipefail
+      export BUCKET_NAME=marcboudreau-$(uuidgen | cut -d- -f1 | tr '[:upper:]' '[:lower:]')-test
+      ./setup-bucket.sh
+      test -z "$(aws s3api get-bucket-acl \
+          --bucket $BUCKET_NAME | \
+        jq -r '.Grants[].Grantee | select(.URI == "http://acs.amazonaws.com/groups/global/AuthenticatedUsers")')"
+      aws s3api delete-bucket \
+          --bucket $BUCKET_NAME
+deployment:
+  deploy-master:
+    branch: master
+    commands:
+      - |
+        BUCKET_NAME=$(jq -r '.variable.bucket_name.default' bucket.tf.json) \
+          ./setup-bucket.sh

--- a/setup-bucket.sh
+++ b/setup-bucket.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+#
+# setup-bucket.sh
+#	Ensures that the account S3 bucket is in place and correctly configured.
+#
+# Usage:
+#	setup-bucket.sh
+#
+# Environment Variables:
+#	AWS_ACCESS_KEY_ID		The ID of the Access Key to use to make AWS API calls.
+#	AWS_SECRET_ACCESS_KEY	The secret Access Key to use to make AWS API calls.
+#   BUCKET_NAME				The name of the bucket to setup correctly.
+#
+
+set -eu
+
+bucket_name=${BUCKET_NAME}
+
+# Check if the bucket exists
+if ! aws s3api head-bucket --bucket $bucket_name 2> /dev/null; then
+	# Create the bucket
+	if ! aws s3api create-bucket --acl private --bucket $bucket_name > /dev/null; then
+		exit 1
+	fi
+fi
+
+# Make sure the right ACL is set
+aws s3api put-bucket-acl --bucket $bucket_name --acl private


### PR DESCRIPTION
Part of the *AWS Account* setup is to have an S3 bucket to act as a storage location for various automated processes.

## Description
This PR introduces a script that will be executed by the Continuous Integration system to ensure that the bucket exists and is correctly configured.

## Testing
The automated testing uses different S3 buckets (not the actual account bucket) to verify the script functionality.  One of the tests uses a permanent S3 bucket that is incorrectly configured.  The test verifies that the script corrected the configuration.  The other test uses a unique bucket name.  The test verifies that the script creates the bucket correctly.