### PR TITLE
Ensuring Bucket Versioning is Enabled

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -7,9 +7,15 @@ test:
       test -z "$(aws s3api get-bucket-acl \
           --bucket $BUCKET_NAME | \
         jq -r '.Grants[].Grantee | select(.URI == "http://acs.amazonaws.com/groups/global/AuthenticatedUsers")')"
+      test -n "$(aws s3api get-bucket-versioning \
+          --bucket $BUCKET_NAME | \
+        jq '.')"
       aws s3api put-bucket-acl \
           --bucket $BUCKET_NAME \
           --acl authenticated-read
+      aws s3api put-bucket-versioning \
+          --bucket $BUCKET_NAME \
+          --versioning-configuration Status=Suspended
     - |
       set -exo pipefail
       export BUCKET_NAME=marcboudreau-$(uuidgen | cut -d- -f1 | tr '[:upper:]' '[:lower:]')-test
@@ -17,6 +23,9 @@ test:
       test -z "$(aws s3api get-bucket-acl \
           --bucket $BUCKET_NAME | \
         jq -r '.Grants[].Grantee | select(.URI == "http://acs.amazonaws.com/groups/global/AuthenticatedUsers")')"
+      test -n "$(aws s3api get-bucket-versioning \
+          --bucket $BUCKET_NAME | \
+        jq '.')"
       aws s3api delete-bucket \
           --bucket $BUCKET_NAME
 deployment:

--- a/setup-bucket.sh
+++ b/setup-bucket.sh
@@ -25,4 +25,15 @@ if ! aws s3api head-bucket --bucket $bucket_name 2> /dev/null; then
 fi
 
 # Make sure the right ACL is set
+<<<<<<< 8eb75ba650f89fb7af2b3676f49adc1395829721
 aws s3api put-bucket-acl --bucket $bucket_name --acl private
+=======
+aws s3api put-bucket-acl \
+		--bucket $bucket_name \
+		--acl private
+
+# Make sure bucket versioning is enabled
+aws s3api put-bucket-versioning \
+		--bucket $bucket_name \
+		--versioning-configuration Status=Enabled
+>>>>>>> Adding bucket versioning

--- a/setup-bucket.sh
+++ b/setup-bucket.sh
@@ -25,9 +25,6 @@ if ! aws s3api head-bucket --bucket $bucket_name 2> /dev/null; then
 fi
 
 # Make sure the right ACL is set
-<<<<<<< 8eb75ba650f89fb7af2b3676f49adc1395829721
-aws s3api put-bucket-acl --bucket $bucket_name --acl private
-=======
 aws s3api put-bucket-acl \
 		--bucket $bucket_name \
 		--acl private
@@ -36,4 +33,3 @@ aws s3api put-bucket-acl \
 aws s3api put-bucket-versioning \
 		--bucket $bucket_name \
 		--versioning-configuration Status=Enabled
->>>>>>> Adding bucket versioning

--- a/terraform/aws.tf
+++ b/terraform/aws.tf
@@ -1,0 +1,11 @@
+terraform {
+  backend "s3" {
+    bucket = "marcboudreau-${var.bucket_name}"
+    key = "terraform/cloud-account-setup/global.tfstate"
+    region = "us-east-1"
+  }
+  required_version = ">= 0.9.0"
+}
+
+provider "aws" {
+}


### PR DESCRIPTION
Bucket Versioning is a feature of S3 buckets where all versions of objects in an S3 bucket are kept.  Since the bucket configured by this project contains data provided/used by automation, there's a higher risk of data being lost.

## Change

This PR modifies the `setup-bucket.sh` to also enable bucket versioning.  Additional tests were also added to the `circle.yml` file to verify that the script functions as expected prior to running it against the **actual** bucket.