### PR TITLE
Refactor project for terraform use

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+terraform/terraform.tfstate*

--- a/bucket.tf.json
+++ b/bucket.tf.json
@@ -1,8 +1,0 @@
-{
-	"variable": {
-		"bucket_name": {
-			"description": "The name of the bucket in which the terraform remote state is stored.",
-			"default": "marcboudreau-371d9884"
-		}
-	}
-}

--- a/circle.yml
+++ b/circle.yml
@@ -2,7 +2,7 @@ test:
   override:
     - |
       set -exo pipefail
-      export BUCKET_NAME=$(jq -r '.variable.bucket_name.default' bucket.tf.json)-test
+      export BUCKET_NAME=$(jq -r '.terraform.backend.s3.bucket' terraform/backend.tf.json)-test
       ./setup-bucket.sh
       test -z "$(aws s3api get-bucket-acl \
           --bucket $BUCKET_NAME | \
@@ -33,5 +33,5 @@ deployment:
     branch: master
     commands:
       - |
-        BUCKET_NAME=$(jq -r '.variable.bucket_name.default' bucket.tf.json) \
+        BUCKET_NAME=$(jq -r '.terraform.backend.s3.bucket' terraform/backend.tf.json) \
           ./setup-bucket.sh

--- a/circle.yml
+++ b/circle.yml
@@ -2,7 +2,7 @@ test:
   override:
     - |
       set -exo pipefail
-      export BUCKET_NAME=$(jq -r '.terraform.backend.s3.bucket' terraform/backend.tf.json)-test
+      export BUCKET_NAME=$(./get-account-bucket.sh)-test
       ./setup-bucket.sh
       test -z "$(aws s3api get-bucket-acl \
           --bucket $BUCKET_NAME | \
@@ -33,5 +33,5 @@ deployment:
     branch: master
     commands:
       - |
-        BUCKET_NAME=$(jq -r '.terraform.backend.s3.bucket' terraform/backend.tf.json) \
+        BUCKET_NAME=$(./get-account-bucket.sh) \
           ./setup-bucket.sh

--- a/get-account-bucket.sh
+++ b/get-account-bucket.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+#
+# get-account-bucket.sh
+#   This script retrieves the name of the S3 bucket from the
+#   terraform/backend.tf.json file.  Since that file is the authoritative source
+#   of the name of the s3 bucket, we need an easy way for other processes to
+#   extract that value.
+#
+set -e
+
+backend_file=terraform/backend.tf.json
+
+jq -r '.terraform.backend.s3.bucket' $backend_file

--- a/terraform/aws.tf
+++ b/terraform/aws.tf
@@ -1,9 +1,4 @@
 terraform {
-  backend "s3" {
-    bucket = "marcboudreau-${var.bucket_name}"
-    key = "terraform/cloud-account-setup/global.tfstate"
-    region = "us-east-1"
-  }
   required_version = ">= 0.9.0"
 }
 

--- a/terraform/backend.tf.json
+++ b/terraform/backend.tf.json
@@ -1,6 +1,6 @@
 {
 	"terraform": {
-		"backend": {
+		"backend" : {
 			"s3": {
 				"bucket": "marcboudreau-371d9884",
 				"key": "terraform/cloud-account-setup/global.tfstate",

--- a/terraform/backend.tf.json
+++ b/terraform/backend.tf.json
@@ -1,0 +1,11 @@
+{
+	"terraform": {
+		"backend": {
+			"s3": {
+				"bucket": "marcboudreau-371d9884",
+				"key": "terraform/cloud-account-setup/global.tfstate",
+				"region": "us-east-1"
+			}
+		}
+	}
+}


### PR DESCRIPTION
The account bucket name was kept in a terraform variable.  The hope was to use the variable value in the backend configuration stanza.  But **terraform** doesn't allow string interpolation in the backend configuration.

## Change
This PR removes the JSON file with the variable that contains the bucket name.  Instead the bucket name is written directly into the backend configuration stanza.  Since the bucket name needs to be retrieved from the JSON file for multiple tests, a script is provided to handle the fetching that value from the backend.tf.json file from a single place.